### PR TITLE
Fix CI workflow to use npm instead of pnpm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,33 +22,13 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 22
-
-      - name: install pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 8
-          run_install: false
-
-      - name: Get pnpm store directory
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-      - name: Setup pnpm cache
-        uses: actions/cache@v3
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
+          cache: 'npm'
 
       - name: Install dependencies
-        run: pnpm install
+        run: npm ci
 
-        # use astro check for issues
       - name: Run check
-        run: pnpm astro check
+        run: npm run check
 
-        # ensure build works
       - name: Run build
-        run: pnpm build
+        run: npm run build

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
 	plugins: {
 		autoprefixer: {},
 		"postcss-import": {},

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,6 +1,5 @@
 ---
 import PageLayout from "@/layouts/Base.astro";
-import { Icon } from "astro-icon/components";
 import { awardsTech } from "@/data/awards";
 ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Fixed the CI workflow that was preventing the website from publishing. The workflow was configured for `pnpm` but the repository uses `npm` (has `package-lock.json` instead of `pnpm-lock.yaml`).

## Changes
- Updated `.github/workflows/ci.yml` to use npm instead of pnpm
- Simplified CI workflow by using built-in npm caching
- Removed unused `Icon` import from `about.astro`
- Converted `postcss.config.js` to ES module format (`postcss.config.mjs`)

## Testing
- ✅ Build passes locally with `npm run build`
- ✅ Type checking passes with no errors or warnings
- ✅ All 11 pages built successfully
- ✅ Pagefind search index generated correctly

This should resolve the CI failures and allow the site to publish successfully to GitHub Pages.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://quant-zsd9795.slack.com/archives/D0ANN088KK6/p1774363274947699?thread_ts=1774363274.947699&cid=D0ANN088KK6)

<div><a href="https://cursor.com/agents/bc-e55430be-35f7-4103-9b3f-cac50d6d968c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e55430be-35f7-4103-9b3f-cac50d6d968c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

