### PR TITLE
Fix home Recent News: valid section structure and IPDPS item

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -66,10 +66,15 @@ const allPostsByDate = sortMDByDate(allPosts).slice(0, MAX_POSTS);
 				</p>
 			</div>
 		</div>
+	</section>
 
 	<section class="mt-16">
 		<h2 class="title mb-4 text-xl">Recent News</h2>
 		<div class="space-y-3">
+			<div class="flex gap-4">
+				<span class="text-sm text-gray-600 min-w-[120px]">[February 2026]</span>
+				<span class="text-sm">Paper accepted to IEEE IPDPS 2026 — <a href="https://arxiv.org/abs/2512.02189" class="cactus-link font-medium" target="_blank" rel="noopener noreferrer">Microbenchmarking NVIDIA's Blackwell Architecture: An in-depth Architectural Analysis</a> (arXiv:2512.02189).</span>
+			</div>
 			<div class="flex gap-4">
 				<span class="text-sm text-gray-600 min-w-[120px]">[February 2026]</span>
 				<span class="text-sm">New preprint <a href="https://arxiv.org/abs/2602.10262" class="cactus-link font-medium" target="_blank" rel="noopener noreferrer">"Execution-Centric Characterization of FP8 Matrix Cores, Asynchronous Execution, and Structured Sparsity on AMD MI300A"</a> published on arXiv!</span>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Recent News on the home page could render incorrectly because the hero block opened a `<section>` that was never closed, so the Recent News block was nested inside it (invalid HTML).

This change closes that section before Recent News and adds the missing **February 2026** item for **IEEE IPDPS 2026** acceptance of [arXiv:2512.02189](https://arxiv.org/abs/2512.02189) (*Microbenchmarking NVIDIA's Blackwell Architecture: An in-depth Architectural Analysis*).

## Verification

- `npm run check` (Astro check) — 0 errors, 0 warnings
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://quant-zsd9795.slack.com/archives/D0ANN088KK6/p1774363274947699?thread_ts=1774363274.947699&cid=D0ANN088KK6)

<div><a href="https://cursor.com/agents/bc-405cbc7e-137e-5e4f-8d2b-80a671c59173"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-405cbc7e-137e-5e4f-8d2b-80a671c59173"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

